### PR TITLE
Add a new option 'strict' that will throw if name already exist

### DIFF
--- a/example.sql
+++ b/example.sql
@@ -11,3 +11,9 @@ UPDATE pokemon SET price=:price;
 
  --dual
 select * from dual;
+
+-- duplicateUpdate
+UPDATE pokemon SET price=:price;
+
+-- duplicateUpdate
+UPDATE pokemon SET price=:price;

--- a/test.js
+++ b/test.js
@@ -82,7 +82,7 @@ it('pg from file', () => {
 it('raw from file', () => {
   const sql = yesql('./')
   assert.equal(sql.updatePokemon, '-- updatePokemon\nUPDATE pokemon SET price=:price;')
-  assert.equal(sql.dual, ' --dual\nselect * from dual;\n')
+  assert.equal(sql.dual, ' --dual\nselect * from dual;')
 })
 
 it('Missing parameter throws error', () => {
@@ -200,3 +200,13 @@ it('PG double quoted strings with colon', () => {
     values: [5]
   })
 })
+it('strict should fail when same name appears more than 1', () => {
+  try {
+    const sql = yesql('./', { strict: true })
+  } catch(err) {
+    assert.equal(err.message, 'Name duplicateUpdate already exists');
+    return;
+  }
+  throw new Error('Should have not reached here');
+})
+

--- a/yesql.js
+++ b/yesql.js
@@ -16,7 +16,12 @@ const readSqlFiles = (dir, options = {}) => {
     value.content.split('\n\n').forEach(sql => {
       if (sql.trim().startsWith('--')) {
         const sqlName = sql.split('\n')[0].trim().substring(2).trim()
-        acc[sqlName] = options.type ? module.exports[options.type](sql, options) : sql
+
+        if (options.strict && acc[sqlName]) {
+          throw new Error('Name ' + sqlName + ' already exists');
+        }
+
+	acc[sqlName] = options.type ? module.exports[options.type](sql, options) : sql
       }
     })
     return acc


### PR DESCRIPTION
I don't want to break existing behaviour, so making this strict option as optional. I think that in future versions it should be the default.